### PR TITLE
Guess runner for slurm and pulsar_embedded too

### DIFF
--- a/sorting_hat.py
+++ b/sorting_hat.py
@@ -275,6 +275,10 @@ def build_spec(tool_spec, dest_spec, runner_hint=None):
 
     if 'condor' in destination:
         runner = 'condor'
+    elif 'slurm' in destination:
+        runner = 'slurm'
+    elif 'pulsar_embedded' in destination:
+        runner = 'pulsar_embedded'
     elif 'remote_cluster_mq' in destination:
         # destination label has to follow this convention:
         # remote_cluster_mq_feature1_feature2_feature3_pulsarid


### PR DESCRIPTION
Making some tests to finally use the sorting_hat on genouest and .fr instance!
I've made this little patch as we have slurm instead of condor, and we use embedded pulsar for gxits