### PR TITLE
User dedicated storage for special user groups

### DIFF
--- a/sorting_hat.py
+++ b/sorting_hat.py
@@ -149,11 +149,11 @@ def assert_permissions(tool_spec, user_email, user_roles):
 def change_object_store_dependent_on_user(params, user_roles):
     """
     Different roles can have their own storage. Here we overwrite the object store based on user associated roles.
-    Example: A user belongs to the role 'nfdi4plants'. Those users own dedicated storage that they include into Galaxy.
-        Here, we change the 'object_store_id' based in the role 'nfdi4plants'.
+    Example: A user belongs to the role 'dataplant'. Those users own dedicated storage that they include into Galaxy.
+        Here, we change the 'object_store_id' based in the role 'dataplant'.
     """
-    if 'nfdi4plants' in user_roles:
-        params['object_store_id'] = 'bwsfs'
+    if 'dataplant' in user_roles:
+        params['object_store_id'] = 'dataplant01'
     return params
     
 

--- a/sorting_hat.py
+++ b/sorting_hat.py
@@ -146,6 +146,16 @@ def assert_permissions(tool_spec, user_email, user_roles):
     # Auth failure.
     raise Exception(exception_text)
 
+def change_object_store_dependent_on_user(params, user_roles):
+    """
+    Different roles can have their own storage. Here we overwrite the object store based on user associated roles.
+    Example: A user belongs to the role 'nfdi4plants'. Those users own dedicated storage that they include into Galaxy.
+        Here, we change the 'object_store_id' based in the role 'nfdi4plants'.
+    """
+    if 'nfdi4plants' in user_roles:
+        params['object_store_id'] = 'bwsfs'
+    return params
+    
 
 def get_tool_id(tool_id):
     """
@@ -432,6 +442,7 @@ def gateway(tool_id, user, memory_scale=1.0, next_dest=None):
         }]
 
     name = name_it(spec)
+    params = change_object_store_dependent_on_user(params, user_roles)
     return JobDestination(
         id=name,
         tags=tags,


### PR DESCRIPTION
@gmauro what do you think about this?

* Are __all__ jobs going through `gateway()` including upload jobs?
* We need to include the bwsfs object store before we merge that. I think we requested a separate mount point already from Kolja many months back.

If this gets merged I will create this Galaxy role and add myself to test it.